### PR TITLE
Use classmap instead.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
 		"php": ">=5.3.0"
 	},
 	"autoload": {
-		"classmap": ["URLify.php"]
+		"psr-0": { "URLify": "" }
 	}
 }


### PR DESCRIPTION
The verdict is out our cool feature was just too cool =)

They suggest we use [classmap](http://getcomposer.org/doc/04-schema.md#autoload) instead.

Included the URLify.php as a classmap for autoloader instead of psr-0.
