### PR TITLE
Added the possibility to priorize urlify language maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,18 @@ URLify::remove_words (array ('remove', 'these', 'too'));
 
 ?>
 ```
+
+To priorize a certain language map:
+
+```php
+<?php
+
+echo URLify::filter (' Ägypten und Österreich besitzen wie üblich ein Übermaß an ähnlich öligen Attachés ',60,"de");
+// "aegypten-und-oesterreich-besitzen-wie-ueblich-ein-uebermass-aehnlich-oeligen-attaches"
+   
+echo URLify::filter ('Cağaloğlu, çalıştığı, müjde, lazım, mahkûm',60,"tr");
+// "cagaloglu-calistigi-mujde-lazim-mahkum"
+
+?>
+```
+Please note that the "ü" is transliterated to "ue" in the first case, whereas it results in a simple "u" in the latter.

--- a/URLify.php
+++ b/URLify.php
@@ -17,7 +17,11 @@
  */
 class URLify {
 	public static $maps = array (
-		'latin_map' => array (
+		'de' => array ( /* German */
+			'Ä' => 'Ae', 'Ö' => 'Oe', 'Ü' => 'Ue', 'ä' => 'ae', 'ö' => 'oe', 'ü' => 'ue', 'ß' => 'ss',
+			'ẞ' => 'SS'
+		),
+		'latin' => array (
 			'À' => 'A', 'Á' => 'A', 'Â' => 'A', 'Ã' => 'A', 'Ä' => 'A', 'Å' => 'A', 'Æ' => 'AE', 'Ç' =>
 			'C', 'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E', 'Ì' => 'I', 'Í' => 'I', 'Î' => 'I',
 			'Ï' => 'I', 'Ð' => 'D', 'Ñ' => 'N', 'Ò' => 'O', 'Ó' => 'O', 'Ô' => 'O', 'Õ' => 'O', 'Ö' =>
@@ -28,10 +32,10 @@ class URLify {
 			'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o', 'ő' => 'o', 'ø' => 'o', 'ù' => 'u', 'ú' => 'u',
 			'û' => 'u', 'ü' => 'u', 'ű' => 'u', 'ý' => 'y', 'þ' => 'th', 'ÿ' => 'y'
 		),
-		'latin_symbols_map' => array (
+		'latin_symbols' => array (
 			'©' => '(c)'
 		),
-		'greek_map' => array (
+		'el' => array ( /* Greek */
 			'α' => 'a', 'β' => 'b', 'γ' => 'g', 'δ' => 'd', 'ε' => 'e', 'ζ' => 'z', 'η' => 'h', 'θ' => '8',
 			'ι' => 'i', 'κ' => 'k', 'λ' => 'l', 'μ' => 'm', 'ν' => 'n', 'ξ' => '3', 'ο' => 'o', 'π' => 'p',
 			'ρ' => 'r', 'σ' => 's', 'τ' => 't', 'υ' => 'y', 'φ' => 'f', 'χ' => 'x', 'ψ' => 'ps', 'ω' => 'w',
@@ -43,11 +47,11 @@ class URLify {
 			'Ά' => 'A', 'Έ' => 'E', 'Ί' => 'I', 'Ό' => 'O', 'Ύ' => 'Y', 'Ή' => 'H', 'Ώ' => 'W', 'Ϊ' => 'I',
 			'Ϋ' => 'Y'
 		),
-		'turkish_map' => array (
+		'tr' => array ( /* Turkish */
 			'ş' => 's', 'Ş' => 'S', 'ı' => 'i', 'İ' => 'I', 'ç' => 'c', 'Ç' => 'C', 'ü' => 'u', 'Ü' => 'U',
 			'ö' => 'o', 'Ö' => 'O', 'ğ' => 'g', 'Ğ' => 'G'
 		),
-		'russian_map' => array (
+		'ru' => array ( /* Russian */
 			'а' => 'a', 'б' => 'b', 'в' => 'v', 'г' => 'g', 'д' => 'd', 'е' => 'e', 'ё' => 'yo', 'ж' => 'zh',
 			'з' => 'z', 'и' => 'i', 'й' => 'j', 'к' => 'k', 'л' => 'l', 'м' => 'm', 'н' => 'n', 'о' => 'o',
 			'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't', 'у' => 'u', 'ф' => 'f', 'х' => 'h', 'ц' => 'c',
@@ -59,25 +63,25 @@ class URLify {
 			'Ч' => 'Ch', 'Ш' => 'Sh', 'Щ' => 'Sh', 'Ъ' => '', 'Ы' => 'Y', 'Ь' => '', 'Э' => 'E', 'Ю' => 'Yu',
 			'Я' => 'Ya'
 		),
-		'ukrainian_map' => array (
+		'uk' => array ( /* Ukrainian */
 			'Є' => 'Ye', 'І' => 'I', 'Ї' => 'Yi', 'Ґ' => 'G', 'є' => 'ye', 'і' => 'i', 'ї' => 'yi', 'ґ' => 'g'
 		),
-		'czech_map' => array (
+		'cs' => array ( /* Czech */
 			'č' => 'c', 'ď' => 'd', 'ě' => 'e', 'ň' => 'n', 'ř' => 'r', 'š' => 's', 'ť' => 't', 'ů' => 'u',
 			'ž' => 'z', 'Č' => 'C', 'Ď' => 'D', 'Ě' => 'E', 'Ň' => 'N', 'Ř' => 'R', 'Š' => 'S', 'Ť' => 'T',
 			'Ů' => 'U', 'Ž' => 'Z'
 		),
-		'polish_map' => array (
+		'pl' => array ( /* Polish */
 			'ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n', 'ó' => 'o', 'ś' => 's', 'ź' => 'z',
 			'ż' => 'z', 'Ą' => 'A', 'Ć' => 'C', 'Ę' => 'e', 'Ł' => 'L', 'Ń' => 'N', 'Ó' => 'O', 'Ś' => 'S',
 			'Ź' => 'Z', 'Ż' => 'Z'
 		),
-		'latvian_map' => array (
+		'lv' => array ( /* Latvian */
 			'ā' => 'a', 'č' => 'c', 'ē' => 'e', 'ģ' => 'g', 'ī' => 'i', 'ķ' => 'k', 'ļ' => 'l', 'ņ' => 'n',
 			'š' => 's', 'ū' => 'u', 'ž' => 'z', 'Ā' => 'A', 'Č' => 'C', 'Ē' => 'E', 'Ģ' => 'G', 'Ī' => 'i',
 			'Ķ' => 'k', 'Ļ' => 'L', 'Ņ' => 'N', 'Š' => 'S', 'Ū' => 'u', 'Ž' => 'Z'
 		),
-		'lithuanian_map' => array (
+		'lt' => array ( /* Lithuanian */
 			'ą' => 'a', 'č' => 'c', 'ę' => 'e', 'ė' => 'e', 'į' => 'i', 'š' => 's', 'ų' => 'u', 'ū' => 'u', 'ž' => 'z',
 			'Ą' => 'A', 'Č' => 'C', 'Ę' => 'E', 'Ė' => 'E', 'Į' => 'I', 'Š' => 'S', 'Ų' => 'U', 'Ū' => 'U', 'Ž' => 'Z'
 		)
@@ -109,12 +113,32 @@ class URLify {
 	private static $regex = '';
 
 	/**
+	 * The current language
+	 */
+	private static $language = '';
+
+	/**
 	 * Initializes the character map.
 	 */
-	private static function init () {
-		if (count (self::$map) > 0) {
+	private static function init ($language = "") {
+		if (count (self::$map) > 0 && (($language == "") || ($language == self::$language))) {
 			return;
 		}
+
+		/* Is a specific map associated with $language ? */
+		if (isset(self::$maps[$language]) && is_array(self::$maps[$language])) {
+			/* Move this map to end. This means it will have priority over others */
+			$m = self::$maps[$language];
+			unset(self::$maps[$language]);
+			self::$maps[$language] = $m;
+			
+			/* Reset static vars */
+			self::$language = $language;
+			self::$map = array();
+			self::$chars = '';
+			self::$regex = '';
+		}
+
 
 		foreach (self::$maps as $map) {
 			foreach ($map as $orig => $conv) {
@@ -149,9 +173,11 @@ class URLify {
 
 	/**
 	 * Transliterates characters to their ASCII equivalents.
+     * $language specifies a priority for a specific language. 
+     * The latter is useful if languages have different rules for the same character.
 	 */
-	public static function downcode ($text) {
-		self::init ();
+	public static function downcode ($text, $language = "") {
+		self::init ($language);
 
 		if (preg_match_all (self::$regex, $text, $matches)) {
 			for ($i = 0; $i < count ($matches[0]); $i++) {
@@ -167,8 +193,8 @@ class URLify {
 	/**
 	 * Filters a string, e.g., "Petty theft" to "petty-theft"
 	 */
-	public static function filter ($text, $length = 60) {
-		$text = self::downcode ($text);
+	public static function filter ($text, $length = 60, $language = "") {
+		$text = self::downcode ($text,$language);
 
 		// remove all these words from the string before urlifying
 		$text = preg_replace ('/\b(' . join ('|', self::$remove_list) . ')\b/i', '', $text);


### PR DESCRIPTION
This is useful if languages have different rules for the same character.
e.g. German: "ü"=>"ue"
Turkish "ü" => "u"
