### PR TITLE
Fix URLify::init() when called with some language

### DIFF
--- a/URLify.php
+++ b/URLify.php
@@ -134,14 +134,11 @@ class URLify {
 			$m = self::$maps[$language];
 			unset(self::$maps[$language]);
 			self::$maps[$language] = $m;
-			
-			/* Reset static vars */
-			self::$language = $language;
-			self::$map = array();
-			self::$chars = '';
-			self::$regex = '';
 		}
-
+		/* Reset static vars */
+		self::$language = $language;
+		self::$map = array();
+		self::$chars = '';
 
 		foreach (self::$maps as $map) {
 			foreach ($map as $orig => $conv) {


### PR DESCRIPTION
If $language is not one for which there's a key in the $maps array, the $chars is not reset and the regular expression becomes longer and longer every time init() is called
