### PR TITLE
Correctly remove all non-latin characters

### DIFF
--- a/URLify.php
+++ b/URLify.php
@@ -228,7 +228,7 @@ class URLify {
 		$text = preg_replace ('/\b(' . join ('|', self::$remove_list) . ')\b/i', '', $text);
 
 		// if downcode doesn't hit, the char will be stripped here
-		$remove_pattern = ($file_name) ? '/[^-.\w\s]/u' : '/[^-\w\s]/u';
+		$remove_pattern = ($file_name) ? '/[^_\-.\w\s]/u' : '/[^\s_\-a-zA-Z0-9]/u';
 		$text = preg_replace ($remove_pattern, '', $text); // remove unneeded chars
 		$text = str_replace ('_', ' ', $text);             // treat underscores as spaces
 		$text = preg_replace ('/^\s+|\s+$/', '', $text);   // trim leading/trailing spaces

--- a/tests/URLifyTest.php
+++ b/tests/URLifyTest.php
@@ -11,6 +11,8 @@ class URLifyTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals ('jetudie-le-francais', URLify::filter ('  J\'étudie le français  '));
 		$this->assertEquals ('lo-siento-no-hablo-espanol', URLify::filter ('Lo siento, no hablo español.'));
 		$this->assertEquals ('f3pws', URLify::filter ('ΦΞΠΏΣ'));
+		$this->assertEquals ('', URLify::filter('大般若經'));
+		$this->assertEquals ('ykrhy-ltoytr', URLify::filter('ياكرهي لتويتر'));
 		$this->assertEquals ('foto.jpg', URLify::filter ('фото.jpg', 60, "", $file_name = true));
 		// priorization of language-specific maps
 		$this->assertEquals ('aouaou', URLify::filter ('ÄÖÜäöü',60,"tr"));


### PR DESCRIPTION
Hello

During usage of this great library I've found out that some characters are skipped and not removed for uri canonicalization. Such as "大般若經". 

This PR ensures that all non-latin characters will be removed from end-result for `URLify::filter`
