### PR TITLE
travis: PHP 7.0 nightly added + few improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:
-  - composer self-update
-  - composer install --no-interaction --prefer-source --dev
+  - composer install --no-interaction --prefer-source
 
 script:
   - phpunit --coverage-text --verbose


### PR DESCRIPTION
- no real need to update composer; waste of travis resources
- `--dev` is by default for couple of months