### PR TITLE
Convert and strip utf-8 spaces

### DIFF
--- a/URLify.php
+++ b/URLify.php
@@ -244,8 +244,8 @@ class URLify {
 		$remove_pattern = ($file_name) ? '/[^_\-.\-a-zA-Z0-9\s]/u' : '/[^\s_\-a-zA-Z0-9]/u';
 		$text = preg_replace ($remove_pattern, '', $text); // remove unneeded chars
 		$text = str_replace ('_', ' ', $text);             // treat underscores as spaces
-		$text = preg_replace ('/^\s+|\s+$/u', '', $text);   // trim leading/trailing spaces
-		$text = preg_replace ('/[-\s]+/u', '-', $text);     // convert spaces to hyphens
+		$text = preg_replace ('/^\s+|\s+$/u', '', $text);  // trim leading/trailing spaces
+		$text = preg_replace ('/[-\s]+/u', '-', $text);    // convert spaces to hyphens
 		$text = strtolower ($text);                        // convert to lowercase
 		return trim (substr ($text, 0, $length), '-');     // trim to first $length chars
 	}

--- a/URLify.php
+++ b/URLify.php
@@ -244,8 +244,8 @@ class URLify {
 		$remove_pattern = ($file_name) ? '/[^_\-.\-a-zA-Z0-9\s]/u' : '/[^\s_\-a-zA-Z0-9]/u';
 		$text = preg_replace ($remove_pattern, '', $text); // remove unneeded chars
 		$text = str_replace ('_', ' ', $text);             // treat underscores as spaces
-		$text = preg_replace ('/^\s+|\s+$/', '', $text);   // trim leading/trailing spaces
-		$text = preg_replace ('/[-\s]+/', '-', $text);     // convert spaces to hyphens
+		$text = preg_replace ('/^\s+|\s+$/u', '', $text);   // trim leading/trailing spaces
+		$text = preg_replace ('/[-\s]+/u', '-', $text);     // convert spaces to hyphens
 		$text = strtolower ($text);                        // convert to lowercase
 		return trim (substr ($text, 0, $length), '-');     // trim to first $length chars
 	}

--- a/tests/URLifyTest.php
+++ b/tests/URLifyTest.php
@@ -20,6 +20,8 @@ class URLifyTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals ('aeoeueaeoeue', URLify::filter ('ÄÖÜäöü',60,"de"));
 
 		$this->assertEquals ('bobby-mcferrin-dont-worry-be-happy', URLify::filter ("Bobby McFerrin — Don't worry be happy",600,"en"));
+		// test stripping and conversion of UTF-8 spaces
+		$this->assertEquals ('test-mahito-mukai', URLify::filter('向井　真人test　(Mahito Mukai)'));
 	}
 
 	function test_add_chars () {


### PR DESCRIPTION
Properly handles utf-8 spaces both at the beginning and in the middle of strings, such as the extra-long spaces added in the new test case.