### PR TITLE
Make usage of remove_list optional

### DIFF
--- a/URLify.php
+++ b/URLify.php
@@ -234,11 +234,13 @@ class URLify {
 	/**
 	 * Filters a string, e.g., "Petty theft" to "petty-theft"
 	 */
-	public static function filter ($text, $length = 60, $language = "", $file_name = false) {
+	public static function filter ($text, $length = 60, $language = "", $file_name = false, $use_remove_list = true) {
 		$text = self::downcode ($text,$language);
 
-		// remove all these words from the string before urlifying
-		$text = preg_replace ('/\b(' . join ('|', self::$remove_list) . ')\b/i', '', $text);
+        if ($use_remove_list) {
+            // remove all these words from the string before urlifying
+            $text = preg_replace ('/\b(' . join ('|', self::$remove_list) . ')\b/i', '', $text);
+        }
 
 		// if downcode doesn't hit, the char will be stripped here
 		$remove_pattern = ($file_name) ? '/[^_\-.\-a-zA-Z0-9\s]/u' : '/[^\s_\-a-zA-Z0-9]/u';

--- a/tests/URLifyTest.php
+++ b/tests/URLifyTest.php
@@ -45,6 +45,10 @@ class URLifyTest extends PHPUnit_Framework_TestCase {
 		}
 	}
 
+	function test_remove_words_disable () {
+		URLify::remove_words (array ('foo', 'bar'));
+		$this->assertEquals ('foo-bar', URLify::filter ('foo bar', 60, '', false, false));
+	}
 }
 
 ?>


### PR DESCRIPTION
Hi,

currently, the removal of words can only be influenced by setting the public static $remove_list property (as seen in #35).

When using URLify in multiple places in a project, this has to be multiple times which seems error-prone. Also, using the remove_list feature in some calls to URLify::filter while disabling it in other calls isn't possible currently.

This pull request adds an additional parameter to the URLify::filter() method to toggle the usage of the remove list feature.

Thx! :)