### PR TITLE
Fix Issue #55

### DIFF
--- a/URLify.php
+++ b/URLify.php
@@ -204,7 +204,7 @@ class URLify
 			}
 		}
 
-		self::$regex = '/[' . self::$chars . ']/u';
+		self::$regex = '/[' . preg_quote(self::$chars, '/') . ']/u';
 	}
 
 	/**


### PR DESCRIPTION
This change fixes a language exception that occurs when a character
that is used as a regular expression delimiter ("/" by default) is
included as a key in the array argument passed into the add_chars()
method, and then downcode() is called.

Note that the existing tests do not cover this scenario.