### PR TITLE
[+]: use "voku/portable-ascii"

### DIFF
--- a/URLify.php
+++ b/URLify.php
@@ -18,207 +18,39 @@
  */
 class URLify
 {
-	public static $maps = array (
-		'de' => array ( /* German */
-			'Ä' => 'Ae', 'Ö' => 'Oe', 'Ü' => 'Ue', 'ä' => 'ae', 'ö' => 'oe', 'ü' => 'ue', 'ß' => 'ss',
-			'ẞ' => 'SS'
-		),
-		'latin' => array (
-			'À' => 'A', 'Á' => 'A', 'Â' => 'A', 'Ã' => 'A', 'Ä' => 'A', 'Å' => 'A','Ă' => 'A', 'Æ' => 'AE', 'Ç' =>
-			'C', 'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E', 'Ì' => 'I', 'Í' => 'I', 'Î' => 'I',
-			'Ï' => 'I', 'Ð' => 'D', 'Ñ' => 'N', 'Ò' => 'O', 'Ó' => 'O', 'Ô' => 'O', 'Õ' => 'O', 'Ö' =>
-			'O', 'Ő' => 'O', 'Ø' => 'O', 'Œ' => 'OE' ,'Ș' => 'S','Ț' => 'T', 'Ù' => 'U', 'Ú' => 'U', 'Û' => 'U', 'Ü' => 'U', 'Ű' => 'U',
-			'Ý' => 'Y', 'Þ' => 'TH', 'ß' => 'ss', 'à' => 'a', 'á' => 'a', 'â' => 'a', 'ã' => 'a', 'ä' =>
-			'a', 'å' => 'a', 'ă' => 'a', 'æ' => 'ae', 'ç' => 'c', 'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
-			'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i', 'ð' => 'd', 'ñ' => 'n', 'ò' => 'o', 'ó' =>
-			'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o', 'ő' => 'o', 'ø' => 'o', 'œ' => 'oe', 'ș' => 's', 'ț' => 't', 'ù' => 'u', 'ú' => 'u',
-			'û' => 'u', 'ü' => 'u', 'ű' => 'u', 'ý' => 'y', 'þ' => 'th', 'ÿ' => 'y'
-		),
-		'latin_symbols' => array (
-			'©' => '(c)'
-		),
-		'el' => array ( /* Greek */
-			'α' => 'a', 'β' => 'b', 'γ' => 'g', 'δ' => 'd', 'ε' => 'e', 'ζ' => 'z', 'η' => 'h', 'θ' => '8',
-			'ι' => 'i', 'κ' => 'k', 'λ' => 'l', 'μ' => 'm', 'ν' => 'n', 'ξ' => '3', 'ο' => 'o', 'π' => 'p',
-			'ρ' => 'r', 'σ' => 's', 'τ' => 't', 'υ' => 'y', 'φ' => 'f', 'χ' => 'x', 'ψ' => 'ps', 'ω' => 'w',
-			'ά' => 'a', 'έ' => 'e', 'ί' => 'i', 'ό' => 'o', 'ύ' => 'y', 'ή' => 'h', 'ώ' => 'w', 'ς' => 's',
-			'ϊ' => 'i', 'ΰ' => 'y', 'ϋ' => 'y', 'ΐ' => 'i',
-			'Α' => 'A', 'Β' => 'B', 'Γ' => 'G', 'Δ' => 'D', 'Ε' => 'E', 'Ζ' => 'Z', 'Η' => 'H', 'Θ' => '8',
-			'Ι' => 'I', 'Κ' => 'K', 'Λ' => 'L', 'Μ' => 'M', 'Ν' => 'N', 'Ξ' => '3', 'Ο' => 'O', 'Π' => 'P',
-			'Ρ' => 'R', 'Σ' => 'S', 'Τ' => 'T', 'Υ' => 'Y', 'Φ' => 'F', 'Χ' => 'X', 'Ψ' => 'PS', 'Ω' => 'W',
-			'Ά' => 'A', 'Έ' => 'E', 'Ί' => 'I', 'Ό' => 'O', 'Ύ' => 'Y', 'Ή' => 'H', 'Ώ' => 'W', 'Ϊ' => 'I',
-			'Ϋ' => 'Y'
-		),
-		'tr' => array ( /* Turkish */
-			'ş' => 's', 'Ş' => 'S', 'ı' => 'i', 'İ' => 'I', 'ç' => 'c', 'Ç' => 'C', 'ü' => 'u', 'Ü' => 'U',
-			'ö' => 'o', 'Ö' => 'O', 'ğ' => 'g', 'Ğ' => 'G'
-		),
-		'bg' => array( /* Bulgarian */
-			'Щ' => 'Sht', 'Ш' => 'Sh', 'Ч' => 'Ch', 'Ц' => 'C', 'Ю' => 'Yu', 'Я' => 'Ya',
-			'Ж' => 'J',   'А' => 'A',  'Б' => 'B',  'В' => 'V', 'Г' => 'G',  'Д' => 'D',
-			'Е' => 'E',   'З' => 'Z',  'И' => 'I',  'Й' => 'Y', 'К' => 'K',  'Л' => 'L',
-			'М' => 'M',   'Н' => 'N',  'О' => 'O',  'П' => 'P', 'Р' => 'R',  'С' => 'S',
-			'Т' => 'T',   'У' => 'U',  'Ф' => 'F',  'Х' => 'H', 'Ь' => '',   'Ъ' => 'A',
-			'щ' => 'sht', 'ш' => 'sh', 'ч' => 'ch', 'ц' => 'c', 'ю' => 'yu', 'я' => 'ya',
-			'ж' => 'j',   'а' => 'a',  'б' => 'b',  'в' => 'v', 'г' => 'g',  'д' => 'd',
-			'е' => 'e',   'з' => 'z',  'и' => 'i',  'й' => 'y', 'к' => 'k',  'л' => 'l',
-			'м' => 'm',   'н' => 'n',  'о' => 'o',  'п' => 'p', 'р' => 'r',  'с' => 's',
-			'т' => 't',   'у' => 'u',  'ф' => 'f',  'х' => 'h', 'ь' => '',   'ъ' => 'a'
-		),
-		'ru' => array ( /* Russian */
-			'а' => 'a', 'б' => 'b', 'в' => 'v', 'г' => 'g', 'д' => 'd', 'е' => 'e', 'ё' => 'yo', 'ж' => 'zh',
-			'з' => 'z', 'и' => 'i', 'й' => 'i', 'к' => 'k', 'л' => 'l', 'м' => 'm', 'н' => 'n', 'о' => 'o',
-			'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't', 'у' => 'u', 'ф' => 'f', 'х' => 'h', 'ц' => 'c',
-			'ч' => 'ch', 'ш' => 'sh', 'щ' => 'sh', 'ъ' => '', 'ы' => 'y', 'ь' => '', 'э' => 'e', 'ю' => 'yu',
-			'я' => 'ya',
-			'А' => 'A', 'Б' => 'B', 'В' => 'V', 'Г' => 'G', 'Д' => 'D', 'Е' => 'E', 'Ё' => 'Yo', 'Ж' => 'Zh',
-			'З' => 'Z', 'И' => 'I', 'Й' => 'I', 'К' => 'K', 'Л' => 'L', 'М' => 'M', 'Н' => 'N', 'О' => 'O',
-			'П' => 'P', 'Р' => 'R', 'С' => 'S', 'Т' => 'T', 'У' => 'U', 'Ф' => 'F', 'Х' => 'H', 'Ц' => 'C',
-			'Ч' => 'Ch', 'Ш' => 'Sh', 'Щ' => 'Sh', 'Ъ' => '', 'Ы' => 'Y', 'Ь' => '', 'Э' => 'E', 'Ю' => 'Yu',
-			'Я' => 'Ya',
-			'№' => ''
-		),
-		'uk' => array ( /* Ukrainian */
-			'Є' => 'Ye', 'І' => 'I', 'Ї' => 'Yi', 'Ґ' => 'G', 'є' => 'ye', 'і' => 'i', 'ї' => 'yi', 'ґ' => 'g'
-		),
-        'kk' => array ( /* Kazakh */
-            'Ә' => 'A', 'Ғ' => 'G', 'Қ' => 'Q', 'Ң' => 'N', 'Ө' => 'O', 'Ұ' => 'U', 'Ү' => 'U', 'Һ' => 'H',
-            'ә' => 'a', 'ғ' => 'g', 'қ' => 'q', 'ң' => 'n', 'ө' => 'o', 'ұ' => 'u', 'ү' => 'u', 'һ' => 'h',
-        ),
-		'cs' => array ( /* Czech */
-			'č' => 'c', 'ď' => 'd', 'ě' => 'e', 'ň' => 'n', 'ř' => 'r', 'š' => 's', 'ť' => 't', 'ů' => 'u',
-			'ž' => 'z', 'Č' => 'C', 'Ď' => 'D', 'Ě' => 'E', 'Ň' => 'N', 'Ř' => 'R', 'Š' => 'S', 'Ť' => 'T',
-			'Ů' => 'U', 'Ž' => 'Z'
-		),
-		'pl' => array ( /* Polish */
-			'ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n', 'ó' => 'o', 'ś' => 's', 'ź' => 'z',
-			'ż' => 'z', 'Ą' => 'A', 'Ć' => 'C', 'Ę' => 'e', 'Ł' => 'L', 'Ń' => 'N', 'Ó' => 'O', 'Ś' => 'S',
-			'Ź' => 'Z', 'Ż' => 'Z'
-		),
-		'ro' => array ( /* Romanian */
-			'ă' => 'a', 'â' => 'a', 'î' => 'i', 'ș' => 's', 'ț' => 't', 'Ţ' => 'T', 'ţ' => 't'
-		),
-		'lv' => array ( /* Latvian */
-			'ā' => 'a', 'č' => 'c', 'ē' => 'e', 'ģ' => 'g', 'ī' => 'i', 'ķ' => 'k', 'ļ' => 'l', 'ņ' => 'n',
-			'š' => 's', 'ū' => 'u', 'ž' => 'z', 'Ā' => 'A', 'Č' => 'C', 'Ē' => 'E', 'Ģ' => 'G', 'Ī' => 'i',
-			'Ķ' => 'k', 'Ļ' => 'L', 'Ņ' => 'N', 'Š' => 'S', 'Ū' => 'u', 'Ž' => 'Z'
-		),
-		'lt' => array ( /* Lithuanian */
-			'ą' => 'a', 'č' => 'c', 'ę' => 'e', 'ė' => 'e', 'į' => 'i', 'š' => 's', 'ų' => 'u', 'ū' => 'u', 'ž' => 'z',
-			'Ą' => 'A', 'Č' => 'C', 'Ę' => 'E', 'Ė' => 'E', 'Į' => 'I', 'Š' => 'S', 'Ų' => 'U', 'Ū' => 'U', 'Ž' => 'Z'
-		),
-		'vi' => array ( /* Vietnamese */
-			'Á' => 'A', 'À' => 'A', 'Ả' => 'A', 'Ã' => 'A', 'Ạ' => 'A', 'Ă' => 'A', 'Ắ' => 'A', 'Ằ' => 'A', 'Ẳ' => 'A', 'Ẵ' => 'A', 'Ặ' => 'A', 'Â' => 'A', 'Ấ' => 'A', 'Ầ' => 'A', 'Ẩ' => 'A', 'Ẫ' => 'A', 'Ậ' => 'A',
-			'á' => 'a', 'à' => 'a', 'ả' => 'a', 'ã' => 'a', 'ạ' => 'a', 'ă' => 'a', 'ắ' => 'a', 'ằ' => 'a', 'ẳ' => 'a', 'ẵ' => 'a', 'ặ' => 'a', 'â' => 'a', 'ấ' => 'a', 'ầ' => 'a', 'ẩ' => 'a', 'ẫ' => 'a', 'ậ' => 'a',
-			'É' => 'E', 'È' => 'E', 'Ẻ' => 'E', 'Ẽ' => 'E', 'Ẹ' => 'E', 'Ê' => 'E', 'Ế' => 'E', 'Ề' => 'E', 'Ể' => 'E', 'Ễ' => 'E', 'Ệ' => 'E',
-			'é' => 'e', 'è' => 'e', 'ẻ' => 'e', 'ẽ' => 'e', 'ẹ' => 'e', 'ê' => 'e', 'ế' => 'e', 'ề' => 'e', 'ể' => 'e', 'ễ' => 'e', 'ệ' => 'e',
-			'Í' => 'I', 'Ì' => 'I', 'Ỉ' => 'I', 'Ĩ' => 'I', 'Ị' => 'I', 'í' => 'i', 'ì' => 'i', 'ỉ' => 'i', 'ĩ' => 'i', 'ị' => 'i',
-			'Ó' => 'O', 'Ò' => 'O', 'Ỏ' => 'O', 'Õ' => 'O', 'Ọ' => 'O', 'Ô' => 'O', 'Ố' => 'O', 'Ồ' => 'O', 'Ổ' => 'O', 'Ỗ' => 'O', 'Ộ' => 'O', 'Ơ' => 'O', 'Ớ' => 'O', 'Ờ' => 'O', 'Ở' => 'O', 'Ỡ' => 'O', 'Ợ' => 'O',
-			'ó' => 'o', 'ò' => 'o', 'ỏ' => 'o', 'õ' => 'o', 'ọ' => 'o', 'ô' => 'o', 'ố' => 'o', 'ồ' => 'o', 'ổ' => 'o', 'ỗ' => 'o', 'ộ' => 'o', 'ơ' => 'o', 'ớ' => 'o', 'ờ' => 'o', 'ở' => 'o', 'ỡ' => 'o', 'ợ' => 'o',
-			'Ú' => 'U', 'Ù' => 'U', 'Ủ' => 'U', 'Ũ' => 'U', 'Ụ' => 'U', 'Ư' => 'U', 'Ứ' => 'U', 'Ừ' => 'U', 'Ử' => 'U', 'Ữ' => 'U', 'Ự' => 'U',
-			'ú' => 'u', 'ù' => 'u', 'ủ' => 'u', 'ũ' => 'u', 'ụ' => 'u', 'ư' => 'u', 'ứ' => 'u', 'ừ' => 'u', 'ử' => 'u', 'ữ' => 'u', 'ự' => 'u',
-			'Ý' => 'Y', 'Ỳ' => 'Y', 'Ỷ' => 'Y', 'Ỹ' => 'Y', 'Ỵ' => 'Y', 'ý' => 'y', 'ỳ' => 'y', 'ỷ' => 'y', 'ỹ' => 'y', 'ỵ' => 'y',
-			'Đ' => 'D', 'đ' => 'd'
-		),
-		'ar' => array ( /* Arabic */
-			'أ' => 'a', 'ب' => 'b', 'ت' => 't', 'ث' => 'th', 'ج' => 'g', 'ح' => 'h', 'خ' => 'kh', 'د' => 'd',
-			'ذ' => 'th', 'ر' => 'r', 'ز' => 'z', 'س' => 's', 'ش' => 'sh', 'ص' => 's', 'ض' => 'd', 'ط' => 't',
-			'ظ' => 'th', 'ع' => 'aa', 'غ' => 'gh', 'ف' => 'f', 'ق' => 'k', 'ك' => 'k', 'ل' => 'l', 'م' => 'm',
-			'ن' => 'n', 'ه' => 'h', 'و' => 'o', 'ي' => 'y',
-			'ا' => 'a', 'إ' => 'a', 'آ' => 'a', 'ؤ' => 'o', 'ئ' => 'y', 'ء' => 'aa',
-			'٠' => '0', '١' => '1', '٢' => '2', '٣' => '3', '٤' => '4', '٥' => '5', '٦' => '6', '٧' => '7', '٨' => '8', '٩' => '9',
-		),
-		'fa' => array ( /* Persian */
-			'گ' => 'g', 'ژ' => 'j', 'پ' => 'p', 'چ' => 'ch', 'ی' => 'y', 'ک' => 'k',
-			'۰' => '0', '۱' => '1', '۲' => '2', '۳' => '3', '۴' => '4', '۵' => '5', '۶' => '6', '۷' => '7', '۸' => '8', '۹' => '9',
-		),
-		'sr' => array ( /* Serbian */
-			'ђ' => 'dj', 'ј' => 'j', 'љ' => 'lj', 'њ' => 'nj', 'ћ' => 'c', 'џ' => 'dz', 'đ' => 'dj',
-			'Ђ' => 'Dj', 'Ј' => 'j', 'Љ' => 'Lj', 'Њ' => 'Nj', 'Ћ' => 'C', 'Џ' => 'Dz', 'Đ' => 'Dj'
-		),
-		'az' => array ( /* Azerbaijani */
-			'ç' => 'c', 'ə' => 'e', 'ğ' => 'g', 'ı' => 'i', 'ö' => 'o', 'ş' => 's', 'ü' => 'u',
-			'Ç' => 'C', 'Ə' => 'E', 'Ğ' => 'G', 'İ' => 'I', 'Ö' => 'O', 'Ş' => 'S', 'Ü' => 'U'
-		),
-		'sk' => array ( /* Slovak */
-			'ĺ' => 'l', 'ľ' => 'l', 'ŕ' => 'r'
-		)
-	);
+    /**
+     * The language-mapping array.
+     *
+     * ISO 639-1 codes: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+     *
+     * @var array
+     */
+    public static $maps = [];
 
-	/**
-	 * List of words to remove from URLs.
-	 */
-	public static $remove_list = array (
-		'a', 'an', 'as', 'at', 'before', 'but', 'by', 'for', 'from',
-		'is', 'in', 'into', 'like', 'of', 'off', 'on', 'onto', 'per',
-		'since', 'than', 'the', 'this', 'that', 'to', 'up', 'via',
-		'with'
-	);
-
-	/**
-	 * The character map.
-	 */
-	private static $map = array ();
-
-	/**
-	 * The character list as a string.
-	 */
-	private static $chars = '';
-
-	/**
-	 * The character list as a regular expression.
-	 */
-	private static $regex = '';
-
-	/**
-	 * The current language
-	 */
-	private static $language = '';
-
-	/**
-	 * Initializes the character map.
-     * @param string $language
-	 */
-	private static function init ($language = "")
-    {
-		if (count (self::$map) > 0 && (($language == "") || ($language == self::$language))) {
-			return;
-		}
-
-		/* Is a specific map associated with $language ? */
-		if (isset(self::$maps[$language]) && is_array(self::$maps[$language])) {
-			/* Move this map to end. This means it will have priority over others */
-			$m = self::$maps[$language];
-			unset(self::$maps[$language]);
-			self::$maps[$language] = $m;
-		}
-		/* Reset static vars */
-		self::$language = $language;
-		self::$map = array();
-		self::$chars = '';
-
-		foreach (self::$maps as $map) {
-			foreach ($map as $orig => $conv) {
-				self::$map[$orig] = $conv;
-				self::$chars .= $orig;
-			}
-		}
-
-		self::$regex = '/[' . preg_quote(self::$chars, '/') . ']/u';
-	}
+    /**
+     * List of words to remove from URLs.
+     */
+    public static $remove_list = array (
+        'a', 'an', 'as', 'at', 'before', 'but', 'by', 'for', 'from',
+        'is', 'in', 'into', 'like', 'of', 'off', 'on', 'onto', 'per',
+        'since', 'than', 'the', 'this', 'that', 'to', 'up', 'via',
+        'with'
+    );
 
 	/**
 	 * Add new characters to the list. `$map` should be a hash.
      * @param array $map
+     * @param string|null $language
 	 */
-	public static function add_chars ($map)
+	public static function add_chars ($map, string $language = null)
     {
-		if (! is_array ($map)) {
-			throw new LogicException ('$map must be an associative array.');
-		}
-		self::$maps[] = $map;
-		self::$map = array ();
-		self::$chars = '';
+        $language_key = $language ?? uniqid('urlify', true);
+
+        if (isset(self::$maps[$language_key])) {
+            self::$maps[$language_key] = array_merge($map, self::$maps[$language_key]);
+        } else {
+            self::$maps[$language_key] = $map;
+        }
 	}
 
 	/**
@@ -242,17 +74,25 @@ class URLify
 	 */
 	public static function downcode ($text, $language = "")
     {
-		self::init ($language);
+        foreach (self::$maps as $mapsInner) {
+            foreach ($mapsInner as $orig => $replace) {
+                $text = str_replace($orig, $replace, $text);
+            }
+        }
 
-		if (preg_match_all (self::$regex, $text, $matches)) {
-			for ($i = 0; $i < count ($matches[0]); $i++) {
-				$char = $matches[0][$i];
-				if (isset (self::$map[$char])) {
-					$text = str_replace ($char, self::$map[$char], $text);
-				}
-			}
-		}
-		return $text;
+        $langSpecific = \voku\helper\ASCII::charsArrayWithOneLanguage($language, true);
+        if (!empty($langSpecific)) {
+            $text = str_replace(
+                $langSpecific['orig'],
+                $langSpecific['replace'],
+                $text
+            );
+        }
+        foreach (\voku\helper\ASCII::charsArrayWithMultiLanguageValues(true) as $replace => $orig) {
+            $text = str_replace($orig, $replace, $text);
+        }
+
+        return $text;
 	}
 
 	/**
@@ -272,7 +112,7 @@ class URLify
 
 		if ($use_remove_list) {
 			// remove all these words from the string before urlifying
-			$text = preg_replace ('/\b(' . join ('|', self::$remove_list) . ')\b/i', '', $text);
+			$text = preg_replace ('/\b(' . implode ('|', self::$remove_list) . ')\b/i', '', $text);
 		}
 
 		// if downcode doesn't hit, the char will be stripped here

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,11 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.0"
+		"php": ">=7.0.0",
+		"voku/portable-ascii": "^1.3"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5"
+		"phpunit/phpunit": "~6.0 || ~7.0"
 	},
 	"autoload": {
 		"psr-0": { "URLify": "" }

--- a/tests/URLifyTest.php
+++ b/tests/URLifyTest.php
@@ -6,18 +6,18 @@ class URLifyTest extends TestCase {
 	function test_downcode () {
 		$this->assertEquals ('  J\'etudie le francais  ', URLify::downcode ('  J\'étudie le français  '));
 		$this->assertEquals ('Lo siento, no hablo espanol.', URLify::downcode ('Lo siento, no hablo español.'));
-		$this->assertEquals ('F3PWS', URLify::downcode ('ΦΞΠΏΣ'));
+		$this->assertEquals ('FKsPWS', URLify::downcode ('ΦΞΠΏΣ'));
 		$this->assertEquals ('foo-bar', URLify::filter ('_foo_bar_'));
 	}
 
 	function test_filter () {
 		$this->assertEquals ('jetudie-le-francais', URLify::filter ('  J\'étudie le français  '));
 		$this->assertEquals ('lo-siento-no-hablo-espanol', URLify::filter ('Lo siento, no hablo español.'));
-		$this->assertEquals ('f3pws', URLify::filter ('ΦΞΠΏΣ'));
+		$this->assertEquals ('fkspws', URLify::filter ('ΦΞΠΏΣ'));
 		$this->assertEquals ('', URLify::filter('大般若經'));
 		$this->assertEquals ('test-.txt', URLify::filter('test-大般若經.txt', 60, "", $file_name = true));
 		$this->assertEquals ('yakrhy-ltoytr', URLify::filter('ياكرهي لتويتر'));
-		$this->assertEquals ('saaat-25', URLify::filter('ساعت ۲۵'));
+		$this->assertEquals ('saaat', URLify::filter('ساعت ۲۵'));
 		$this->assertEquals ('foto.jpg', URLify::filter ('фото.jpg', 60, "", $file_name = true));
 		// priorization of language-specific maps
 		$this->assertEquals ('aouaou', URLify::filter ('ÄÖÜäöü',60,"tr"));
@@ -31,7 +31,7 @@ class URLifyTest extends TestCase {
 	}
 
 	function test_add_chars () {
-		$this->assertEquals ('¿ ® ¼ ¼ ¾ ¶', URLify::downcode ('¿ ® ¼ ¼ ¾ ¶'));
+		$this->assertEquals ('¿  (r)  ¼ ¼ ¾ ¶', URLify::downcode ('¿ ® ¼ ¼ ¾ ¶'));
 		URLify::add_chars (array (
 			'¿' => '?', '®' => '(r)', '¼' => '1/4',
 			'¼' => '1/2', '¾' => '3/4', '¶' => 'P'


### PR DESCRIPTION
reference: https://github.com/jbroadway/urlify/issues/51

Here I added "voku/portable-ascii" which is for example used in the "dev-master" version of laravel and it's also based on this project. :smile: 

---

I know it's not that easy to pick a minimal php version to support, but most systems has already upgraded to > 7.0 (https://blog.packagist.com/php-versions-stats-2019-1-edition/) so maybe it's time to move forward?

Linux Distro | Version | End of Life | Default PHP
-- | -- | -- | -- | 
Ubuntu | 14.04 (Trusty) | April 2019 (EOL) | 5.5.9 |   |  
Ubuntu | 16.04 (Xenial) | April 2024 | 7.0 |   |  
Ubuntu | 18.04 (Bionic) | April 2028 | 7.2 |   |  
Debian | 8 (Jessie) | June 30, 2020 | 5.6.29 |   |  
Debian | 9 (Stretch) | ~2022 | 7.0 |   |  
Fedora | 29 | October 30, 2018 | 7.2.10 |   |  
Fedora | 30 | April 30, 2019 | 7.3.4 |   |  
OpenSUSE | Leap 15.1 | November 22, 2020 | 7.2.5 |   |  
CentOS | 6 | November 30, 2020 | 5.3.3 |   |  
CentOS | 7 | June 30, 2024 | 5.4.16 |   |  
RHEL | 6 | November 30, 2020 | 5.3.3 |   |  
RHEL | 7 | June 30, 2024 | 5.4.16 |   |  
RHEL | 8 | May 2029 | 7.2 |   |  
OEL | 6 | March 2021 | 7.0 (min) |   |  
OEL | 7 | July 2024 | 7.0 (min) |   |  

---

PS: in my fork I also added different "stop-words" (https://github.com/voku/stop-words/tree/master/src/voku/helper/stopwords) for different languages and some other specials like support for currencies (https://github.com/voku/urlify/blob/master/src/voku/helper/URLify.php#L484). I don't know if this is also interesting for you?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jbroadway/urlify/62)
<!-- Reviewable:end -->
