### PR TITLE
Explicitly mark language as nullable in add_chars, to fix deprecation

### DIFF
--- a/URLify.php
+++ b/URLify.php
@@ -71,7 +71,7 @@ class URLify
      *
      * @psalm-param array<string, string> $map
      */
-    public static function add_chars(array $map, string $language = null)
+    public static function add_chars(array $map, ?string $language = null)
     {
         $language_key = $language ?? \uniqid('urlify', true);
 


### PR DESCRIPTION
In PHP 8.4, having a parameter be explicitly nullable is deprecated. This pull request fixes this for `add_chars`.